### PR TITLE
Add GearBot to bot list

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Use the following bots to create your own custom commands and functionality. The
 |-|-|
 | [Zira.gg](https://zira.gg) | Zira lets users add and remove roles for themselves by simply reacting to a message. |
 | [Ticket Tool](https://tickettool.xyz/) | Ticket Tool is a highly versatile support bot for Discord. It allows private support channels, or Tickets, between your staff team and individual users to be created. |
+| [GearBot](https://gearbot.rocks) | GearBot is a feature-rich moderation bot, which allows easy automatic moderation with censored words, infraction management, and utility commands, to help you maintain a positive and welcoming server. |
 
 ### Tips & Tricks
 - Have multiple admins that can create and manage roles, channels, and permissions as needed and have a clear rotation of admins through the lenght of the event that can react to the event needs.


### PR DESCRIPTION
This PR adds [GearBot](https://gearbot.rocks) to the list of recommended bots. This is a widely used moderation bot, used by many official Discord servers, and comes with a wide array of manual and automatic moderation tools.